### PR TITLE
Enable python 3.8 and 3.9

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -146,6 +146,9 @@ disable=abstract-method,
         wrong-import-order,
         xrange-builtin,
         zip-builtin-not-iterating,
+# Support pre-3.10 usages
+        consider-alternative-union-syntax,
+        deprecated-typing-alias,
 
 
 [REPORTS]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,6 @@
   },
   "python.terminal.activateEnvInCurrentTerminal": true,
   "python.terminal.activateEnvironment": true,
-  "autoDocstring.startOnNewLine": true
+  "autoDocstring.startOnNewLine": true,
+  "python.linting.mypyCategorySeverity.error": "Information"
 }

--- a/aiopagerduty/__init__.py
+++ b/aiopagerduty/__init__.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2022-present Ravi Terala <terala.work@gmail.com>
 # SPDX-License-Identifier: MIT
-
 """pagerduty module exported APIs
 """
 from aiopagerduty.client import *

--- a/aiopagerduty/client.py
+++ b/aiopagerduty/client.py
@@ -1,7 +1,6 @@
 """aiopagerduty Client module
 """
 
-
 from aiopagerduty.fetcher import Fetcher
 from aiopagerduty.integrations_mixin import IntegrationsMixin
 from aiopagerduty.prioritites_mixin import PrioritiesMixin
@@ -12,13 +11,8 @@ from aiopagerduty.users_mixin import UsersMixin
 from aiopagerduty.vendors_mixin import VendorsMixin
 
 
-class Client(ServiceOrchestrationsMixin,
-             VendorsMixin,
-             PrioritiesMixin,
-             TeamsMixin,
-             ServicesMixin,
-             UsersMixin,
-             IntegrationsMixin,
+class Client(ServiceOrchestrationsMixin, VendorsMixin, PrioritiesMixin,
+             TeamsMixin, ServicesMixin, UsersMixin, IntegrationsMixin,
              Fetcher):
     """aiopagerduty Client API
     """

--- a/aiopagerduty/integrations_mixin.py
+++ b/aiopagerduty/integrations_mixin.py
@@ -1,7 +1,6 @@
 """Integrations Mixin
 """
 
-
 from aiopagerduty.fetcher import FetcherProtocol
 from aiopagerduty.models import Integration, Service, Vendor
 
@@ -9,6 +8,7 @@ from aiopagerduty.models import Integration, Service, Vendor
 class IntegrationsMixin:
     """Integrations API
     """
+
     async def list_integration(self: FetcherProtocol, service_id: str,
                                integration_id: str) -> Integration:
         url = f'services/{service_id}/integrations/{integration_id}'

--- a/aiopagerduty/models.py
+++ b/aiopagerduty/models.py
@@ -3,7 +3,7 @@
 
 import datetime
 from enum import Enum
-from typing import Literal
+from typing import Literal, List, Optional
 
 from pydantic import BaseModel, EmailStr
 
@@ -11,15 +11,15 @@ from pydantic import BaseModel, EmailStr
 class ObjectRef(BaseModel):
     id: str
     summary: str
-    self: str    # url
-    html_url: str | None  # Vendor does not always have a html_url defined
+    self: str  # url
+    html_url: Optional[str]  # Vendor does not always have a html_url defined
     type: str
 
 
 class SupportHours(BaseModel):
     type: str
     time_zone: str
-    days_of_week: list[int]
+    days_of_week: List[int]
     start_time: str
     end_time: str
 
@@ -34,7 +34,7 @@ class ServiceStatus(str, Enum):
 
 class Team(ObjectRef):
     name: str
-    description: str | None
+    description: Optional[str]
 
 
 # class IncidentUrgencyType(str, Enum):
@@ -53,27 +53,27 @@ class IncidentUrgencyDefinition(BaseModel):
 
 
 class IncidentUrgencyRule(IncidentUrgencyDefinition):
-    during_support_hours: IncidentUrgencyDefinition | None
-    outside_support_hours: IncidentUrgencyDefinition | None
+    during_support_hours: Optional[IncidentUrgencyDefinition]
+    outside_support_hours: Optional[IncidentUrgencyDefinition]
 
 
 class Service(ObjectRef):
     """Service defined in PagerDuty
     """
     name: str
-    description: str | None
+    description: Optional[str]
     type: str
-    auto_resolve_timeout: int | None
-    acknowledgement_timeout: int | None
+    auto_resolve_timeout: Optional[int]
+    acknowledgement_timeout: Optional[int]
     created_at: datetime.datetime
     status: ServiceStatus
-    last_incident_timestamp: datetime.datetime | None
+    last_incident_timestamp: Optional[datetime.datetime]
     escalation_policy: ObjectRef
     # response_play: Optional[ObjectRef] = None
-    teams: list[ObjectRef]
-    integrations: list[ObjectRef]
+    teams: List[ObjectRef]
+    integrations: List[ObjectRef]
     incident_urgency_rule: IncidentUrgencyRule
-    support_hours: ObjectRef | None
+    support_hours: Optional[ObjectRef]
 
     class Config:
         use_enum_values = True
@@ -83,10 +83,10 @@ class Vendor(ObjectRef):
     name: str
     type: str
     website_url: str
-    logo_url: str | None
-    thumbnail_url: str | None
-    description: str | None
-    integration_guide_url: str | None
+    logo_url: Optional[str]
+    thumbnail_url: Optional[str]
+    description: Optional[str]
+    integration_guide_url: Optional[str]
 
 
 class EmailFilterMode(str, Enum):
@@ -128,13 +128,13 @@ class Integration(ObjectRef):
     integration_key: str
     service: ObjectRef
     created_at: datetime.datetime
-    vendor: ObjectRef | None
-    integration_email: str | None
-    email_incident_creation: EmailIncidentCreation | None
-    email_filter_mode: EmailFilterMode | None
-    # email_parsers: list[EmailParser]
-    email_parsing_fallback: EmailParsingFallback | None
-    email_filters: list[EmailFilter] | None
+    vendor: Optional[ObjectRef]
+    integration_email: Optional[str]
+    email_incident_creation: Optional[EmailIncidentCreation]
+    email_filter_mode: Optional[EmailFilterMode]
+    # email_parsers: List[EmailParser]
+    email_parsing_fallback: Optional[EmailParsingFallback]
+    email_filters: Optional[List[EmailFilter]]
 
     class Config:
         use_enum_values = True
@@ -159,13 +159,13 @@ class User(ObjectRef):
     time_zone: str
     color: str
     role: UserRole
-    avatar_role: str | None
-    description: str | None
-    invitation_sent: bool | None
-    job_title: str | None
-    teams: list[ObjectRef] | None
-    contact_methods: list[ObjectRef] | None
-    notification_rules: list[ObjectRef] | None
+    avatar_role: Optional[str]
+    description: Optional[str]
+    invitation_sent: Optional[bool]
+    job_title: Optional[str]
+    teams: Optional[List[ObjectRef]]
+    contact_methods: Optional[List[ObjectRef]]
+    notification_rules: Optional[List[ObjectRef]]
 
     class Config:
         use_enum_values = True
@@ -210,14 +210,14 @@ class ConferenceType(str, Enum):
 
 class ResponsePlay(ObjectRef):
     team: Team
-    subscribers: list[ObjectRef]  # TODO: This should be User | Group?
-    subscribers_message: str | None
-    responders: list[ObjectRef] | None
-    responders_message: str | None
-    runnability: Runnability | None
-    conference_number: str | None
-    conference_url: str | None
-    conference_type: ConferenceType | None
+    subscribers: List[ObjectRef]  # TODO: This should be User | Group?
+    subscribers_message: Optional[str]
+    responders: Optional[List[ObjectRef]]
+    responders_message: Optional[str]
+    runnability: Optional[Runnability]
+    conference_number: Optional[str]
+    conference_url: Optional[str]
+    conference_type: Optional[ConferenceType]
 
 
 class ServiceOrchestrationStatus(BaseModel):
@@ -286,38 +286,39 @@ class Extraction(BaseModel):
     # eg: `High CPU on {{hostname}} server`
     template: str
 
-    source: str | None
-    regex: str | None
+    source: Optional[str]
+    regex: Optional[str]
 
 
 class Action(BaseModel):
     """Defines an action in service orchestration rules."""
-    route_to: str | None  # route_to does not exist in catch_all actions
+    route_to: Optional[str]  # route_to does not exist in catch_all actions
 
     # severity: Severity  # Severity of resulting alert
-    severity: str | None  # TODO: issue to fix.
+    severity: Optional[str]  # TODO: issue to fix.
 
     # Suppress the resulting alert
-    suppress: bool | None
+    suppress: Optional[bool]
     # Number of seconds to suspend the resuling alert before triggering
-    suspend: int | None
+    suspend: Optional[int]
 
     # Priority id for the priority defined for the account.
-    priority: str | None
+    priority: Optional[str]
     # Add text as a note to the resulting incident
-    annotate: str | None
+    annotate: Optional[str]
 
-    # Indicates whether the rule is disabled and would therefore not be evaluated.
-    disabled: bool | None
+    # Indicates whether the rule is disabled and would therefore not be
+    # evaluated.
+    disabled: Optional[bool]
 
     # Set whether the resulting alert status is trigger or resolve
-    event_action: EventAction | None
+    event_action: Optional[EventAction]
     # Populate variables from event payloads and use those variables in
     # other event actions.
-    variables: list[Variable] | None
+    variables: Optional[List[Variable]]
 
     # use a template string and variables
-    extractions: list[Extraction] | None
+    extractions: Optional[List[Extraction]]
 
     class Config:
         use_enum_values = True
@@ -329,9 +330,9 @@ class Actions(BaseModel):
 
 class Rule(BaseModel):
     id: str
-    label: str | None
-    disabled: bool | None
-    conditions: list[Condition]
+    label: Optional[str]
+    disabled: Optional[bool]
+    conditions: List[Condition]
     actions: Action
 
     class Config:
@@ -340,7 +341,7 @@ class Rule(BaseModel):
 
 class RuleSet(BaseModel):
     id: str
-    rules: list[Rule]
+    rules: List[Rule]
 
     class Config:
         use_enum_values = True
@@ -351,13 +352,13 @@ class ServiceOrchestration(BaseModel):
     """
     type: str
     parent: RefType
-    version: str | None
+    version: Optional[str]
     self: str
-    updated_at: datetime.datetime | None
-    updated_by: RefType | None
+    updated_at: Optional[datetime.datetime]
+    updated_by: Optional[RefType]
     created_at: datetime.datetime
-    created_by: RefType | None
-    sets: list[RuleSet] | None
+    created_by: Optional[RefType]
+    sets: Optional[List[RuleSet]]
     catch_all: Actions
 
     class Config:

--- a/aiopagerduty/prioritites_mixin.py
+++ b/aiopagerduty/prioritites_mixin.py
@@ -3,8 +3,11 @@
 from aiopagerduty.fetcher import FetcherProtocol
 from aiopagerduty.models import Priority
 
+from typing import List
+
 
 class PrioritiesMixin:
-    async def list_priorities(self: FetcherProtocol) -> list[Priority]:
+
+    async def list_priorities(self: FetcherProtocol) -> List[Priority]:
         query_url = 'priorities'
         return await self.multi_fetch(Priority, query_url, 'priorities')

--- a/aiopagerduty/serviceorchestration_mixin.py
+++ b/aiopagerduty/serviceorchestration_mixin.py
@@ -9,9 +9,9 @@ class ServiceOrchestrationsMixin:
     """ServiceOrchestration API Mixin
     """
 
-    async def list_service_orchestration_status(self: FetcherProtocol,
-                                                service_ref: ObjectRef
-                                                ) -> ServiceOrchestrationStatus:
+    async def list_service_orchestration_status(
+            self: FetcherProtocol,
+            service_ref: ObjectRef) -> ServiceOrchestrationStatus:
         """Return the service orchestration status of a service.
 
         Args:
@@ -23,9 +23,9 @@ class ServiceOrchestrationsMixin:
         url = f'event_orchestrations/services/{service_ref.id}/active'
         return await self.object_fetch(ServiceOrchestrationStatus, url)
 
-    async def update_service_orchestration_status(self: FetcherProtocol, service_ref: ObjectRef,
-                                                  status: ServiceOrchestrationStatus
-                                                  ) -> ServiceOrchestrationStatus:
+    async def update_service_orchestration_status(
+            self: FetcherProtocol, service_ref: ObjectRef,
+            status: ServiceOrchestrationStatus) -> ServiceOrchestrationStatus:
         """Enable/disable service orchestration status for a service.
         Args:
             service_ref (ObjectRef): Object reference to the service
@@ -39,8 +39,9 @@ class ServiceOrchestrationsMixin:
         status_new = ServiceOrchestrationStatus(**json)
         return status_new
 
-    async def list_service_orchestration(self: FetcherProtocol,
-                                         service_ref: ObjectRef) -> ServiceOrchestration:
+    async def list_service_orchestration(
+            self: FetcherProtocol,
+            service_ref: ObjectRef) -> ServiceOrchestration:
         """Get Service Orchestration rules defined for a service.
 
         Args:
@@ -51,4 +52,5 @@ class ServiceOrchestrationsMixin:
         """
         url = f'event_orchestrations/services/{service_ref.id}'
         # return await self._object_fetch(ServiceOrchestration, url)
-        return await self.single_fetch(ServiceOrchestration, url, 'orchestration_path')
+        return await self.single_fetch(ServiceOrchestration, url,
+                                       'orchestration_path')

--- a/aiopagerduty/services_mixin.py
+++ b/aiopagerduty/services_mixin.py
@@ -3,12 +3,14 @@
 
 from aiopagerduty.fetcher import FetcherProtocol
 from aiopagerduty.models import Service
+from typing import List
 
 
 class ServicesMixin:
     """Services API Mixin
     """
-    async def list_services(self: FetcherProtocol) -> list[Service]:
+
+    async def list_services(self: FetcherProtocol) -> List[Service]:
         """Fetch all services.
 
         Returns:
@@ -17,5 +19,5 @@ class ServicesMixin:
         return await self.multi_fetch(Service, 'services', 'services')
 
     async def list_service(self: FetcherProtocol, service_id: str) -> Service:
-        return await self.single_fetch(Service,
-                                       f'services/{service_id}', 'service')
+        return await self.single_fetch(Service, f'services/{service_id}',
+                                       'service')

--- a/aiopagerduty/teams_mixin.py
+++ b/aiopagerduty/teams_mixin.py
@@ -4,13 +4,17 @@
 from aiopagerduty.fetcher import FetcherProtocol
 from aiopagerduty.models import Team, TeamMember
 
+from typing import List
+
 
 class TeamsMixin:
     """Teams API Mixin
     """
-    async def list_teams(self: FetcherProtocol) -> list[Team]:
+
+    async def list_teams(self: FetcherProtocol) -> List[Team]:
         return await self.multi_fetch(Team, 'teams', 'teams')
 
-    async def list_team_members(self: FetcherProtocol, team: Team) -> list[TeamMember]:
-        return await self.multi_fetch(TeamMember,
-                                      f'teams/{team.id}/members', 'members')
+    async def list_team_members(self: FetcherProtocol,
+                                team: Team) -> List[TeamMember]:
+        return await self.multi_fetch(TeamMember, f'teams/{team.id}/members',
+                                      'members')

--- a/aiopagerduty/users_mixin.py
+++ b/aiopagerduty/users_mixin.py
@@ -2,7 +2,7 @@
 """
 
 import urllib
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 from aiopagerduty.fetcher import FetcherProtocol
 from aiopagerduty.models import ResponsePlay, User
@@ -11,22 +11,27 @@ from aiopagerduty.models import ResponsePlay, User
 class UsersMixin:
     """Users API Mixin
     """
+
     async def list_user(self: FetcherProtocol, user_id: str) -> User:
         return await self.single_fetch(User, f'users/{user_id}', 'user')
 
     # Response Plays
 
-    async def list_response_plays(self: FetcherProtocol, query: str | None = None,
-                                  manual: bool = False) -> list[ResponsePlay]:
-        query_params: dict[str, Any] = {
+    async def list_response_plays(self: FetcherProtocol,
+                                  query: Optional[str] = None,
+                                  manual: bool = False) -> List[ResponsePlay]:
+        query_params: Dict[str, Any] = {
             'filter_for_manual_run': manual,
         }
         if query is not None:
             query_params['query'] = query
 
         query_url = f'response_plays?filter_for_manual_run={urllib.parse.urlencode(query_params)}'
-        return await self.multi_fetch(ResponsePlay, query_url, 'response_plays')
+        return await self.multi_fetch(ResponsePlay, query_url,
+                                      'response_plays')
 
-    async def list_response_play(self: FetcherProtocol, reponseplay_id: str) -> ResponsePlay:
+    async def list_response_play(self: FetcherProtocol,
+                                 reponseplay_id: str) -> ResponsePlay:
         query_url = f'response_plays/{reponseplay_id}'
-        return await self.single_fetch(ResponsePlay, query_url, 'response_play')
+        return await self.single_fetch(ResponsePlay, query_url,
+                                       'response_play')

--- a/aiopagerduty/vendors_mixin.py
+++ b/aiopagerduty/vendors_mixin.py
@@ -1,18 +1,19 @@
 """Vendors Mixin
 """
 
-
 from async_lru import alru_cache
 
 from aiopagerduty.fetcher import FetcherProtocol
 from aiopagerduty.models import Vendor
+from typing import List
 
 
 class VendorsMixin:
     """Vendors API Mixin
     """
+
     @alru_cache(maxsize=5)
-    async def list_vendors(self: FetcherProtocol) -> list[Vendor]:
+    async def list_vendors(self: FetcherProtocol) -> List[Vendor]:
         """List of vendors with integrations.
         This list is cached since there are more than 400 vendors defined in the system.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,15 @@ build-backend = "hatchling.build"
 name = "aiopagerduty"
 description = "Asynchronous client for PagerDuty API"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 license = "MIT"
 keywords = ["pagerduty", "async"]
 authors = [{ name = "Ravi Terala", email = "terala.work@gmail.com" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
@@ -21,6 +23,7 @@ classifiers = [
 dependencies = [
   "asyncio",
   "aiohttp",
+  "aiodns",
   "async_lru",
   "aiohttp-client-cache",
   "pydantic[email]",
@@ -58,7 +61,11 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov-report
 no-cov = "cov --no-cov"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["310"]
+python = ["38", "39", "310"]
+
+[tool.hatch.envs.test.overrides]
+name.py311.env-vars = ["MULTIDICT_NO_EXTENSIONS=1", "YARL_NO_EXTENSIONS=1"]
+
 
 [tool.hatch.envs.lint]
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import os
-from typing import AsyncGenerator, cast
+from typing import AsyncGenerator, cast, Dict
 
 import aiopagerduty
 import pytest_asyncio
@@ -40,16 +40,16 @@ async def pd_client(pd_api_key: str) -> AsyncGenerator[aiopagerduty.Client, None
 
 
 @pytest_asyncio.fixture(name="pd_services", scope="session")
-async def aiopagerduty_services(pd: aiopagerduty.Client) -> dict[str, aiopagerduty.Service]:
+async def aiopagerduty_services(pd: aiopagerduty.Client) -> Dict[str, aiopagerduty.Service]:
     svcs = await pd.list_services()
-    services: dict[str, aiopagerduty.Service] = {}
+    services: Dict[str, aiopagerduty.Service] = {}
     for s in svcs:
         services[s.name] = s
     return services
 
 
 @pytest_asyncio.fixture(name="service", scope="session")
-def subject_service(pd_services: dict[str, aiopagerduty.Service],
+def subject_service(pd_services: Dict[str, aiopagerduty.Service],
                     service_name: str) -> aiopagerduty.Service:
     assert_that(pd_services).contains_key(service_name)
     svc = pd_services[service_name]

--- a/tests/test_service_orchestration.py
+++ b/tests/test_service_orchestration.py
@@ -1,7 +1,7 @@
 """Unit tests for Service Orchestration
 """
 import json
-from typing import Callable, TypeVar
+from typing import Callable, TypeVar, Optional, List, Dict
 
 import aiopagerduty
 import pytest
@@ -13,14 +13,14 @@ TArg = TypeVar("TArg")
 TResult = TypeVar("TResult")
 
 
-def find_matching(arr: list[T], pred_fn: Callable[[T], bool]) -> T | None:
+def find_matching(arr: List[T], pred_fn: Callable[[T], bool]) -> Optional[T]:
     for x in arr:
         if pred_fn(x) is True:
             return x
     return None
 
 
-def find_matching_or_throw(arr: list[T], pred_fn: Callable[[T], bool]) -> T:
+def find_matching_or_throw(arr: List[T], pred_fn: Callable[[T], bool]) -> T:
     val: T | None = find_matching(arr, pred_fn)
     if val is None:
         raise LookupError()
@@ -155,7 +155,7 @@ async def test_load_service_orchestrations(pd: aiopagerduty.Client,
 @pytest.mark.parametrize("svc_name,active", [
     ("Test Service", True)])
 async def test_service_orchestration_status(pd: aiopagerduty.Client,
-                                            pd_services: dict[str, aiopagerduty.Service],
+                                            pd_services: Dict[str, aiopagerduty.Service],
                                             svc_name: str, active: bool) -> None:
     assert_that(pd_services).contains_key(svc_name)
     svc = pd_services[svc_name]


### PR DESCRIPTION
Use older type hints to enable `aiopagerduty` to work with Python `3.8` and `3.9`.